### PR TITLE
zip iter

### DIFF
--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -30,7 +30,13 @@ impl LabelledZId {
 }
 
 impl<'a> Expr<'a> {
-    pub fn zip(&self, zipper: &[ZNode]) -> Self {
+    pub fn zip(&self, zipper: &'a[ZNode]) -> Self {
+        self.zip_iter(zipper.iter())
+    }
+
+    #[inline]
+    pub fn zip_iter<T>(&self, zipper: T) -> Self
+    where T: Iterator<Item = &'a ZNode> {
         let mut e = *self;
         for znode in zipper {
             e = match znode {


### PR DESCRIPTION
Running

```
cargo run --release --bin=benchmark_cogsci -- --count 10
```

on the stitch repo, it's

Before: Summary (95% CI, arithmetic mean): 1132.92 [1131.69, 1134.45]
After: Summary (95% CI, arithmetic mean): 1127.80 [1126.63, 1129.08]

no real change in performance